### PR TITLE
Update Azure CLI References to Specify 1.0

### DIFF
--- a/threat-manager/marketplace/README.md
+++ b/threat-manager/marketplace/README.md
@@ -7,7 +7,7 @@ This template allows you to deploy an Alert Logic Threat Manager VM, using the l
 #### Requirements
 [Create Azure Account](https://account.windowsazure.com/Home/Index)
 
-[Install Azure CLI tools](https://azure.microsoft.com/en-us/documentation/articles/xplat-cli-install/)
+[Install Azure CLI 1.0](https://docs.microsoft.com/en-us/cli/azure/install-cli-version-1.0?view=azure-cli-latest)
 
 [Azure Storage Account](https://azure.microsoft.com/en-us/documentation/articles/storage-create-storage-account/#create-a-storage-account)
 
@@ -17,9 +17,9 @@ This template allows you to deploy an Alert Logic Threat Manager VM, using the l
 
 If you do not have a pre-existing Storage Account and Blob Container available, follow the steps below to create them.
 
- * Install Azure CLI tools from the link in the requirements section
+ * Install Azure CLI 1.0 from the link in the requirements section
  * Authenticate your session with Azure from CLI:
- 
+
  ```
  # azure login
  info:    Executing command login
@@ -29,11 +29,11 @@ If you do not have a pre-existing Storage Account and Blob Container available, 
  info:    login command OK
  #
  ```
- 
+
  * Click the 'Azure Storage Account' link in the requirements section and follow the steps to create a new storage account.
  * Create a Blob service container within your storage account by clicking Blobs -> + Container
  * Copy your storage account access key:
- 
+
  > View and copy storage access keys
  >
  > In the Azure Portal, navigate to your storage account and click the Keys icon to view, copy, and regenerate your account access keys. The Access Keys blade also includes pre-configured connection strings using your primary and secondary keys that you can copy to use in your applications
@@ -106,19 +106,19 @@ data:    Name                Display Name         Latitude  Longitude
 data:    ------------------  -------------------  --------  ---------
 data:    eastasia            East Asia            22.267    114.188  
 data:    southeastasia       Southeast Asia       1.283     103.833  
-data:    centralus           Central US           41.5908   -93.6208 
-data:    eastus              East US              37.3719   -79.8164 
-data:    eastus2             East US 2            36.6681   -78.3889 
-data:    westus              West US              37.783    -122.417 
-data:    northcentralus      North Central US     41.8819   -87.6278 
+data:    centralus           Central US           41.5908   -93.6208
+data:    eastus              East US              37.3719   -79.8164
+data:    eastus2             East US 2            36.6681   -78.3889
+data:    westus              West US              37.783    -122.417
+data:    northcentralus      North Central US     41.8819   -87.6278
 data:    southcentralus      South Central US     29.4167   -98.5    
 data:    northeurope         North Europe         53.3478   -6.2597  
 data:    westeurope          West Europe          52.3667   4.9      
-data:    japanwest           Japan West           34.6939   135.5022 
+data:    japanwest           Japan West           34.6939   135.5022
 data:    japaneast           Japan East           35.68     139.77   
 data:    brazilsouth         Brazil South         -23.55    -46.633  
-data:    australiaeast       Australia East       -33.86    151.2094 
-data:    australiasoutheast  Australia Southeast  -37.8136  144.9631 
+data:    australiaeast       Australia East       -33.86    151.2094
+data:    australiasoutheast  Australia Southeast  -37.8136  144.9631
 data:    southindia          South India          12.9822   80.1636  
 data:    centralindia        Central India        18.5822   73.9197  
 data:    westindia           West India           19.088    72.868   
@@ -156,7 +156,7 @@ info:    Executing command group deployment create
 info:    Supply values for the following parameters
 storageAccountName: storageaccountname
 blobContainerName: containername
-availabilitySetName: myavset 
+availabilitySetName: myavset
 numberOfInstances: 2
 vmName: mythreatmanager
 virtualNetworkName: myvnet
@@ -190,7 +190,7 @@ data:    publicNicName                        String        mypubnic
 data:    subnetName                           String        mysubnet
 data:    vmSize                               String        Standard_A3                                                        
 info:    group deployment create command OK
-# 
+#
 ```
 
 Your new deployment should successfully create the 'myNewTMVM' VM
@@ -215,4 +215,3 @@ publicNicName: (Unique name for Public Network Interface)
 subnetName: (Existing subnet within your selected virtual network. If you are creating a new Virtual Network, this name can be unique.)
 vmSize: (Defaults to Standard_A3)
 ```
-

--- a/threat-manager/shared_vhd/README.md
+++ b/threat-manager/shared_vhd/README.md
@@ -7,7 +7,7 @@ This template allows you to deploy an Alert Logic Threat Manager VM, using the l
 #### Requirements
 [Create Azure Account](https://account.windowsazure.com/Home/Index)
 
-[Install Azure CLI tools](https://azure.microsoft.com/en-us/documentation/articles/xplat-cli-install/)
+[Install Azure CLI 1.0](https://docs.microsoft.com/en-us/cli/azure/install-cli-version-1.0?view=azure-cli-latest)
 
 [Azure Storage Account](https://azure.microsoft.com/en-us/documentation/articles/storage-create-storage-account/#create-a-storage-account)
 
@@ -17,9 +17,9 @@ This template allows you to deploy an Alert Logic Threat Manager VM, using the l
 
 If you do not have a pre-existing Storage Account and Blob Container available, follow the steps below to create them.
 
- * Install Azure CLI tools from the link in the requirements section
+ * Install Azure CLI 1.0 from the link in the requirements section
  * Authenticate your session with Azure from CLI:
- 
+
  ```
  # azure login
  info:    Executing command login
@@ -29,17 +29,17 @@ If you do not have a pre-existing Storage Account and Blob Container available, 
  info:    login command OK
  #
  ```
- 
+
  * Click the 'Azure Storage Account' link in the requirements section and follow the steps to create a new storage account.
  * Create a Blob service container within your storage account by clicking Blobs -> + Container
  * Copy your storage account access key:
- 
+
  > View and copy storage access keys
  >
  > In the Azure Portal, navigate to your storage account and click the Keys icon to view, copy, and regenerate your account access keys. The Access Keys blade also includes pre-configured connection strings using your primary and secondary keys that you can copy to use in your applications
- 
+
  * Open a terminal or command prompt and set azure cli mode to asm
- 
+
  ```
  # azure config mode asm
  info:    Executing command config mode
@@ -47,9 +47,9 @@ If you do not have a pre-existing Storage Account and Blob Container available, 
  info:    config mode command OK
  #
  ```
- 
+
  *  Copy the Alert Logic Threat Manager vhd to your storage account
-  
+
  > azure vm disk upload http://alertlogic.blob.core.windows.net/tmcimage/al-tmc-image_latest.vhd [storage account URL]/[blob container name]/[filename].vhd [storage-account-key]
 
  ```
@@ -132,19 +132,19 @@ data:    Name                Display Name         Latitude  Longitude
 data:    ------------------  -------------------  --------  ---------
 data:    eastasia            East Asia            22.267    114.188  
 data:    southeastasia       Southeast Asia       1.283     103.833  
-data:    centralus           Central US           41.5908   -93.6208 
-data:    eastus              East US              37.3719   -79.8164 
-data:    eastus2             East US 2            36.6681   -78.3889 
-data:    westus              West US              37.783    -122.417 
-data:    northcentralus      North Central US     41.8819   -87.6278 
+data:    centralus           Central US           41.5908   -93.6208
+data:    eastus              East US              37.3719   -79.8164
+data:    eastus2             East US 2            36.6681   -78.3889
+data:    westus              West US              37.783    -122.417
+data:    northcentralus      North Central US     41.8819   -87.6278
 data:    southcentralus      South Central US     29.4167   -98.5    
 data:    northeurope         North Europe         53.3478   -6.2597  
 data:    westeurope          West Europe          52.3667   4.9      
-data:    japanwest           Japan West           34.6939   135.5022 
+data:    japanwest           Japan West           34.6939   135.5022
 data:    japaneast           Japan East           35.68     139.77   
 data:    brazilsouth         Brazil South         -23.55    -46.633  
-data:    australiaeast       Australia East       -33.86    151.2094 
-data:    australiasoutheast  Australia Southeast  -37.8136  144.9631 
+data:    australiaeast       Australia East       -33.86    151.2094
+data:    australiasoutheast  Australia Southeast  -37.8136  144.9631
 data:    southindia          South India          12.9822   80.1636  
 data:    centralindia        Central India        18.5822   73.9197  
 data:    westindia           West India           19.088    72.868   
@@ -183,7 +183,7 @@ info:    Supply values for the following parameters
 storageAccountName: storageaccountname
 blobContainerName: containername
 osDiskVhdUri: http://storageaccountname.blob.core.windows.net/containername/al-tmc-image_latest.vhd
-availabilitySetName: myavset 
+availabilitySetName: myavset
 numberOfInstances: 2
 vmName: mythreatmanager
 virtualNetworkName: myvnet
@@ -218,7 +218,7 @@ data:    publicNicName                        String        mypubnic
 data:    subnetName                           String        mysubnet
 data:    vmSize                               String        Standard_A3                                                        
 info:    group deployment create command OK
-# 
+#
 ```
 
 Your new deployment should successfully create the 'myNewTMVM' VM
@@ -244,4 +244,3 @@ publicNicName: (Unique name for Public Network Interface)
 subnetName: (Existing subnet within your selected virtual network. If you are creating a new Virtual Network, this name can be unique.)
 vmSize: (Defaults to Standard_A3)
 ```
-

--- a/web-security-manager/shared_vhd/README.md
+++ b/web-security-manager/shared_vhd/README.md
@@ -7,7 +7,7 @@ This template allows you to deploy an Alert Logic Web Security Manager VM, using
 #### Requirements
 [Create Azure Account](https://account.windowsazure.com/Home/Index)
 
-[Install Azure CLI tools](https://azure.microsoft.com/en-us/documentation/articles/xplat-cli-install/)
+[Install Azure CLI 1.0](https://docs.microsoft.com/en-us/cli/azure/install-cli-version-1.0?view=azure-cli-latest)
 
 [Azure Storage Account](https://azure.microsoft.com/en-us/documentation/articles/storage-create-storage-account/#create-a-storage-account)
 
@@ -17,9 +17,9 @@ This template allows you to deploy an Alert Logic Web Security Manager VM, using
 
 If you do not have a pre-existing Storage Account and Blob Container available, follow the steps below to create them.
 
- * Install Azure CLI tools from the link in the requirements section
+ * Install Azure CLI 1.0 from the link in the requirements section
  * Authenticate your session with Azure from CLI:
- 
+
  ```
  # azure login
  info:    Executing command login
@@ -29,17 +29,17 @@ If you do not have a pre-existing Storage Account and Blob Container available, 
  info:    login command OK
  #
  ```
- 
+
  * Click the 'Azure Storage Account' link in the requirements section and follow the steps to create a new storage account.
  * Create a Blob service container within your storage account by clicking Blobs -> + Container
  * Copy your storage account access key:
- 
+
  > View and copy storage access keys
  >
  > In the Azure Portal, navigate to your storage account and click the Keys icon to view, copy, and regenerate your account access keys. The Access Keys blade also includes pre-configured connection strings using your primary and secondary keys that you can copy to use in your applications
- 
+
  * Open a terminal or command prompt and set azure cli mode to asm
- 
+
  ```
  # azure config mode asm
  info:    Executing command config mode
@@ -47,9 +47,9 @@ If you do not have a pre-existing Storage Account and Blob Container available, 
  info:    config mode command OK
  #
  ```
- 
+
  *  Copy the Alert Logic Web Security Manager vhd to your storage account
-  
+
  > azure vm disk upload http://alertlogic.blob.core.windows.net/wsmimage/al-wsm-image-latest.vhd [storage account URL]/[blob container name]/[filename].vhd [storage-account-key]
 
  ```
@@ -132,19 +132,19 @@ data:    Name                Display Name         Latitude  Longitude
 data:    ------------------  -------------------  --------  ---------
 data:    eastasia            East Asia            22.267    114.188  
 data:    southeastasia       Southeast Asia       1.283     103.833  
-data:    centralus           Central US           41.5908   -93.6208 
-data:    eastus              East US              37.3719   -79.8164 
-data:    eastus2             East US 2            36.6681   -78.3889 
-data:    westus              West US              37.783    -122.417 
-data:    northcentralus      North Central US     41.8819   -87.6278 
+data:    centralus           Central US           41.5908   -93.6208
+data:    eastus              East US              37.3719   -79.8164
+data:    eastus2             East US 2            36.6681   -78.3889
+data:    westus              West US              37.783    -122.417
+data:    northcentralus      North Central US     41.8819   -87.6278
 data:    southcentralus      South Central US     29.4167   -98.5    
 data:    northeurope         North Europe         53.3478   -6.2597  
 data:    westeurope          West Europe          52.3667   4.9      
-data:    japanwest           Japan West           34.6939   135.5022 
+data:    japanwest           Japan West           34.6939   135.5022
 data:    japaneast           Japan East           35.68     139.77   
 data:    brazilsouth         Brazil South         -23.55    -46.633  
-data:    australiaeast       Australia East       -33.86    151.2094 
-data:    australiasoutheast  Australia Southeast  -37.8136  144.9631 
+data:    australiaeast       Australia East       -33.86    151.2094
+data:    australiasoutheast  Australia Southeast  -37.8136  144.9631
 data:    southindia          South India          12.9822   80.1636  
 data:    centralindia        Central India        18.5822   73.9197  
 data:    westindia           West India           19.088    72.868   
@@ -183,7 +183,7 @@ info:    Supply values for the following parameters
 storageAccountName: storageaccountname
 blobContainerName: containername
 osDiskVhdUri: http://storageaccountname.blob.core.windows.net/containername/al-wsm-image-latest.vhd
-availabilitySetName: myavset 
+availabilitySetName: myavset
 numberOfInstances: 2
 vmName: mywebsecuritymanager
 virtualNetworkName: myvnet
@@ -218,7 +218,7 @@ data:    publicNicName                        String        mypubnic
 data:    subnetName                           String        mysubnet
 data:    vmSize                               String        Standard_A3                                                        
 info:    group deployment create command OK
-# 
+#
 ```
 
 Your new deployment should successfully create the 'myNewTMVM' VM
@@ -244,4 +244,3 @@ publicNicName: (Unique name for Public Network Interface)
 subnetName: (Existing subnet within your selected virtual network. If you are creating a new Virtual Network, this name can be unique.)
 vmSize: (Defaults to Standard_A3)
 ```
-


### PR DESCRIPTION
Azure CLI 2.0 has been released and is the default download link now.  These documents require Azure CLI 1.0, which can still be downloaded, or run in a Docker container.  Links and verbiage have been updated and validated.